### PR TITLE
Significant digits REPL representation

### DIFF
--- a/src/Measurements.jl
+++ b/src/Measurements.jl
@@ -101,6 +101,17 @@ measurement
 # Type representation
 Base.show(io::IO, measure::Measurement) =
     print(io, measure.val, get(io, :compact, false) ? "±" : " ± ", measure.err)
+function Base.show( io::IO, ::MIME"text/plain", m::Measurement )
+    if get( io, :limit, false )
+       print( io, round( m.val, digits = -Base.hidigit( m.err, 10 ) + 2 ),
+            get(io, :compact, false) ? "±" : " ± ",
+            round( m.err, sigdigits=2)
+        )
+    else
+       print( io, m )
+    end # if
+end
+
 Base.show(io::IO, ::MIME"text/latex", measure::Measurement) =
     print(io, "\$", measure.val, " \\pm ", measure.err, "\$")
 for mime in (MIME"text/x-tex", MIME"text/x-latex")


### PR DESCRIPTION
shows only significant digits of `Measurement` objects in the REPL.
Relates to https://github.com/JuliaPhysics/Measurements.jl/issues/5 as a proof of concept.